### PR TITLE
Validators now check for null explicitly.

### DIFF
--- a/src/validators.js
+++ b/src/validators.js
@@ -15,9 +15,9 @@ export type ValidationError = {
   reasons: Object
 };
 
-export function required(label: string): (value: string | typeof undefined) => ?ValidationError {
-  return(value: string | typeof undefined) => {
-    if (value === undefined || value === '') {
+export function required(label: string): (value: ?string ) => ?ValidationError {
+  return(value: ?string) => {
+    if (value == null || value === '') {
       return {
         type: 'ERROR_REQUIRED',
         label,
@@ -32,9 +32,9 @@ export function required(label: string): (value: string | typeof undefined) => ?
   };
 }
 
-export function minimumLength(label: string, minimumLength: number): (value: string | typeof undefined) => ?ValidationError {
-  return (value: string | typeof undefined) => {
-    if (value !== undefined && value.length < minimumLength) {
+export function minimumLength(label: string, minimumLength: number): (value: ?string) => ?ValidationError {
+  return (value: ?string) => {
+    if (value != null && value.length < minimumLength) {
       return {
         type: 'ERROR_MINIMUM_LENGTH',
         label,
@@ -49,9 +49,9 @@ export function minimumLength(label: string, minimumLength: number): (value: str
   };
 }
 
-export function maximumLength(label: string, maximumLength: number): (value: string | typeof undefined) => ?ValidationError {
-  return (value: string | typeof undefined) => {
-    if (value !== undefined && value.length > maximumLength) {
+export function maximumLength(label: string, maximumLength: number): (value: ?string) => ?ValidationError {
+  return (value: ?string) => {
+    if (value != null && value.length > maximumLength) {
       return {
         type: 'ERROR_MAXIMUM_LENGTH',
         label,
@@ -66,9 +66,9 @@ export function maximumLength(label: string, maximumLength: number): (value: str
   };
 }
 
-export function minValue(label: string, minValue: number): (value: number | typeof undefined) => ?ValidationError {
-  return (value: number | typeof undefined) => {
-    if (value !== undefined && value < minValue) {
+export function minValue(label: string, minValue: number): (value: ?number) => ?ValidationError {
+  return (value: ?number) => {
+    if (value != null && value < minValue) {
       return {
         type: 'ERROR_MIN_VALUE',
         label,
@@ -83,9 +83,9 @@ export function minValue(label: string, minValue: number): (value: number | type
   };
 }
 
-export function maxValue(label: string, maxValue: number): (value: number | typeof undefined) => ?ValidationError {
-  return (value: number | typeof undefined) => {
-    if (value !== undefined && value > maxValue) {
+export function maxValue(label: string, maxValue: number): (value: ?number) => ?ValidationError {
+  return (value: ?number) => {
+    if (value != null && value > maxValue) {
       return {
         type: 'ERROR_MAX_VALUE',
         label,
@@ -100,9 +100,9 @@ export function maxValue(label: string, maxValue: number): (value: number | type
   };
 }
 
-export function pattern(label: string, regex: RegExp): (value: number | typeof undefined) => ?ValidationError {
-  return (value: number | typeof undefined) => {
-    if (value !== undefined && regex.test(`${value}`) === false) {
+export function pattern(label: string, regex: RegExp): (value: ?number) => ?ValidationError {
+  return (value: ?number) => {
+    if (value != null && regex.test(`${value}`) === false) {
       return {
         type: 'ERROR_PATTERN',
         label,

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -11,6 +11,13 @@ test('required', () => {
     "reasons": { "required": "required" }
   });
 
+  expect(validator(null)).toEqual({
+    "type": "ERROR_REQUIRED",
+    "label": "Name",
+    "value": null,
+    "reasons": { "required": "required" }
+  });
+
   expect(validator('')).toEqual({
     "type": "ERROR_REQUIRED",
     "label": "Name",
@@ -45,6 +52,7 @@ test('minimumLength', () => {
   });
 
   expect(validator(undefined)).toBe(undefined);
+  expect(validator(null)).toBe(undefined);
   expect(validator('aaa')).toBe(undefined);
   expect(validator('aaaa')).toBe(undefined);
 });
@@ -67,6 +75,7 @@ test('maximumLength', () => {
   });
 
   expect(validator(undefined)).toBe(undefined);
+  expect(validator(null)).toBe(undefined);
   expect(validator('')).toBe(undefined);
   expect(validator('a')).toBe(undefined);
   expect(validator('aa')).toBe(undefined);
@@ -91,6 +100,7 @@ test('minValue', () => {
   });
 
   expect(validator(undefined)).toBe(undefined);
+  expect(validator(null)).toBe(undefined);
   expect(validator(15)).toBe(undefined);
   expect(validator(16)).toBe(undefined);
 });
@@ -113,6 +123,7 @@ test('maxValue', () => {
   });
 
   expect(validator(undefined)).toBe(undefined);
+  expect(validator(null)).toBe(undefined);
   expect(validator(15)).toBe(undefined);
   expect(validator(14)).toBe(undefined);
 });
@@ -128,6 +139,7 @@ test('pattern', () => {
   });
 
   expect(validator(undefined)).toBe(undefined);
+  expect(validator(null)).toBe(undefined);
   expect(validator(15)).toBe(undefined);
   expect(validator(14)).toBe(undefined);
 });


### PR DESCRIPTION
The required validator now says null | undefined | '' are invalid.

All other validators now say that null and undefined are in fact valid
values.